### PR TITLE
Limited the Hikari pool size

### DIFF
--- a/src/main/kotlin/org/jetbrains/ktor/heroku/Main.kt
+++ b/src/main/kotlin/org/jetbrains/ktor/heroku/Main.kt
@@ -26,6 +26,7 @@ import java.io.File
 
 val hikariConfig = HikariConfig().apply {
     jdbcUrl = System.getenv("JDBC_DATABASE_URL")
+    maximumPoolSize = 5
 }
 
 val dataSource = if (hikariConfig.jdbcUrl != null)


### PR DESCRIPTION
The free version of Heroku has a limit of 20 connections per database. If there is no limit on the Hikari pool size, it will open as many connections as it can, thus making it impossible to debug the app from 2 machines with the production database. 

A limit of 5 connections should be enough for 4 instances of the app running simultaneously. At the very least `maximumPoolSize = 1` makes the source of the problem visible.